### PR TITLE
Use HTTPS for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "loe/ratings/management/LeagueOfElo"]
 	path = loe/ratings/management/LeagueOfElo
-	url = git@github.com:jprMesh/LeagueOfElo.git
+	url = https://github.com/jprmesh/LeagueOfElo.git


### PR DESCRIPTION
This makes it easier for anonymous developers (or automated systems) to clone the repo without having SSH public keys registered with GitHub.