### PR TITLE
Add basic Docker image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+# Even if the repo is cloned on Windows, these scripts will execute in a Linux
+# environment (potentially through Docker). Be sure to use LF line endings.
+*.sh text eol=lf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,7 @@ RUN python3 -m venv venv \
 # Set environment variables that Django will read.
 ENV SECRET_KEY=secret_key \
     DEBUG=True \
+    FORCE_USE_POSTGRESQL=True \
     DJANGO_POSTGRES_PASS=django_password \
     EMAIL_ACCT=placeholder_email_account \
     EMAIL_PASS=placeholder_email_password

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:latest
+
+# Install system packages.
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y build-essential python3-venv python3-dev postgresql \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a virtual environment and install python dependencies.
+RUN python3 -m venv venv \
+    && . /venv/bin/activate \
+    && python -m pip install -U pip \
+    && python -m pip install django psycopg2 django-colorfield \
+        python-decouple mwclient numpy djangorestframework netifaces gunicorn \
+        gevent
+
+# Set environment variables that Django will read.
+ENV SECRET_KEY=secret_key \
+    DEBUG=True \
+    DJANGO_POSTGRES_PASS=django_password \
+    EMAIL_ACCT=placeholder_email_account \
+    EMAIL_PASS=placeholder_email_password
+
+# Configure the database for Django.
+RUN service postgresql start \
+    && echo "CREATE DATABASE django; \
+        CREATE ROLE django WITH LOGIN PASSWORD '${DJANGO_POSTGRES_PASS}'; \
+        GRANT ALL PRIVILEGES ON DATABASE django TO django;" \
+        | su - postgres -c psql
+
+# Expose the default Django port.
+EXPOSE 8000
+
+# Copy and configure the entrypoint.
+COPY entrypoint.sh .
+ENTRYPOINT [ "/bin/bash", "entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,10 +5,12 @@ cd /src/loe
 python manage.py collectstatic --noinput
 python manage.py migrate
 python manage.py populate_teams
+
 # TODO: enable once I know how these should work
 # python manage.py populate_matches
 # python manage.py createsuperuser
 # python manage.py shell
+# python manage.py calcuate_elo
 
 # Explicitly specify 0.0.0.0 to bind on all network interfaces. Without this
 # Django will only listen on loopback and won't be able to talk to the host.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+service postgresql start
+. /venv/bin/activate
+cd /src/loe
+python manage.py collectstatic --noinput
+python manage.py migrate
+python manage.py populate_teams
+# TODO: enable once I know how these should work
+# python manage.py populate_matches
+# python manage.py createsuperuser
+# python manage.py shell
+
+# Explicitly specify 0.0.0.0 to bind on all network interfaces. Without this
+# Django will only listen on loopback and won't be able to talk to the host.
+python manage.py runserver 0.0.0.0:8000

--- a/loe/loe/settings.py
+++ b/loe/loe/settings.py
@@ -99,7 +99,9 @@ WSGI_APPLICATION = 'loe.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
-if not DEBUG:
+FORCE_USE_POSTGRESQL = config('FORCE_USE_POSTGRESQL', default=False, cast=bool)
+
+if not DEBUG or FORCE_USE_POSTGRESQL:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',

--- a/readme.md
+++ b/readme.md
@@ -25,3 +25,36 @@ python manage.py calculate_elo
 ```
 python manage.py runserver
 ```
+
+## Experimental Docker setup
+
+This application has been containerized using the Dockerfile in the `docker`
+directory. While the current container is sufficient to run the server with
+a PostgreSQL database, match population and ELO calculation steps are missing
+from setup. To try it out, first [install Docker](https://docs.docker.com/get-docker/),
+then build the image. All commands are relative to the repo root.
+
+```
+$ docker image build -t loe_django docker
+```
+
+It may take a few minutes to build the first time, but Docker will cache the
+result. Once it completes, you'll have a image named `loe_django` with Django
+and PostgreSQL installed, and PostgreSQL configured for Django to connect. To
+run the server, run this command. Replace `$PWD` with the current directory if
+running on Windows.
+
+```
+$ docker container run --rm -p 8000:8000 -v $PWD:/src league
+```
+
+After startup completes, you should be able to connect by visiting
+[http://127.0.0.1:8000/](http://127.0.0.1:8000/) in a browser. This command
+maps port 8000 in the container to port 8000 on the host, mounts the current
+directory (containing the source code) as `/src` in the container, and
+instructs Docker to automatically remove the container when the container
+stops with the `--rm` flag.
+
+Because the source code is volume mounted, you should be able to edit the files
+locally in your editor of choice and have the changes be automatically
+reflected in the container.


### PR DESCRIPTION
Currently not supported:

- Match population
- LeaugeOfElo (model) user creation
- ELO calculation
- Email for password reset